### PR TITLE
[issue-4/fix-backoff-kubectl-retry] create a new cmd on every retry

### DIFF
--- a/pkg/kubernetes/kubectl.go
+++ b/pkg/kubernetes/kubectl.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// maxRetries defines the number of retries for kubectl commands.
-	maxRetries = 3
+	maxRetries = 10
 
 	// defaultNamespace is the namespace that should be used where namespace is
 	// omitted.
@@ -55,10 +55,9 @@ func (k *Kubectl) ApplyManifest(manifest api.Manifest) error {
 
 	args = append(args, k.globalArgs...)
 
-	cmd := exec.Command(args[0], args[1:]...)
-
 	err := backoff.Retry(
 		func() error {
+			cmd := exec.Command(args[0], args[1:]...)
 			cmd.Stdin = bytes.NewBuffer(manifest)
 			_, err := k.executor.Run(cmd)
 			return err
@@ -81,10 +80,9 @@ func (k *Kubectl) DeleteManifest(manifest api.Manifest) error {
 
 	args = append(args, k.globalArgs...)
 
-	cmd := exec.Command(args[0], args[1:]...)
-
 	err := backoff.Retry(
 		func() error {
+			cmd := exec.Command(args[0], args[1:]...)
 			cmd.Stdin = bytes.NewBuffer(manifest)
 			_, err := k.executor.Run(cmd)
 			return err
@@ -140,6 +138,7 @@ func (k *Kubectl) DeleteResource(deletion *api.Deletion) error {
 	cmd := exec.Command(args[0], args[1:]...)
 
 	_, err := k.executor.Run(cmd)
+
 	return err
 }
 


### PR DESCRIPTION
fixes #4

It also increases the maxRetries for apply and delete to account for situations where a fresh cluster is not fully ready when the first apply is run against it.