### PR TITLE
[issue-1/config-file-support] add --config flag

### DIFF
--- a/cmd/kcm/commands/config.go
+++ b/cmd/kcm/commands/config.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	configDumpOutput string
+
+	dumpConfigCmd = &cobra.Command{
+		Use:   "dump-config",
+		Short: "Dumps the config to stdout",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateOutput(cmd)
+		},
+		RunE: dumpConfig,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(dumpConfigCmd)
+	dumpConfigCmd.Flags().StringVar(&configDumpOutput, "output", "", "Output format")
+}
+
+func dumpConfig(cmd *cobra.Command, args []string) error {
+	switch configDumpOutput {
+	case "json":
+		buf, err := json.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(buf))
+	case "yaml":
+		buf, err := yaml.Marshal(cfg)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(buf))
+	default:
+		fmt.Printf("%s config %#v\n", rootCmd.Use, cfg)
+	}
+
+	return nil
+}

--- a/cmd/kcm/commands/version.go
+++ b/cmd/kcm/commands/version.go
@@ -16,6 +16,9 @@ var (
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Displays the version",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateOutput(cmd)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := version.Get()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,21 +1,32 @@
 package config
 
-type Config struct {
-	Debug            bool   `json:"debug"`
-	DryRun           bool   `json:"dryRun"`
-	OnlyManifest     bool   `json:"onlyManifest"`
-	WorkingDir       string `json:"workingDir"`
-	Manifest         string `json:"manifest"`
-	Values           string `json:"values"`
-	Deletions        string `json:"deletions"`
-	ManifestRenderer string `json:"manifestRenderer"`
-	InfraManager     string `json:"infraManager"`
+import "github.com/imdario/mergo"
 
-	Cluster   ClusterConfig   `json:"cluster"`
-	Terraform TerraformConfig `json:"terraform"`
-	Helm      HelmConfig      `json:"helm"`
+// Config holds the configuration for kcm.
+type Config struct {
+	Debug            bool   `json:"debug" yaml:"debug"`
+	DryRun           bool   `json:"dryRun" yaml:"dryRun"`
+	OnlyManifest     bool   `json:"onlyManifest" yaml:"onlyManifest"`
+	WorkingDir       string `json:"workingDir" yaml:"workingDir"`
+	Manifest         string `json:"manifest" yaml:"manifest"`
+	Values           string `json:"values" yaml:"values"`
+	Deletions        string `json:"deletions" yaml:"deletions"`
+	ManifestRenderer string `json:"manifestRenderer" yaml:"maniestRenderer"`
+	InfraManager     string `json:"infraManager" yaml:"infraManager"`
+
+	Cluster   ClusterConfig   `json:"cluster" yaml:"cluster"`
+	Terraform TerraformConfig `json:"terraform" yaml:"terraform"`
+	Helm      HelmConfig      `json:"helm" yaml:"helm"`
 }
 
+// Merge merges other into c. Fields in c that do not have their default value
+// will not be overwritten.
+func (c *Config) Merge(other *Config) error {
+	return mergo.Merge(c, other)
+}
+
+// ApplyDefaults applies sane default values to fields that are not explicitly
+// set.
 func (c *Config) ApplyDefaults() {
 	if c.Manifest == "" {
 		c.Manifest = c.WorkingDir + "/manifest.yaml"
@@ -34,11 +45,12 @@ func (c *Config) ApplyDefaults() {
 	}
 }
 
+// ClusterConfig holds configuration accessing a kubernetes cluster.
 type ClusterConfig struct {
-	Server     string `json:"server"`
-	Token      string `json:"token"`
-	Kubeconfig string `json:"kubeconfig"`
-	Context    string `json:"context"`
+	Server     string `json:"server" yaml:"server"`
+	Token      string `json:"token" yaml:"token"`
+	Kubeconfig string `json:"kubeconfig" yaml:"kubeconfig"`
+	Context    string `json:"context" yaml:"context"`
 }
 
 // Update tries to update the cluster config from values retrieved from the
@@ -62,10 +74,12 @@ func (c *ClusterConfig) Update(values map[string]interface{}) {
 	}
 }
 
+// TerraformConfig holds flags for terraform commands.
 type TerraformConfig struct {
-	Parallelism int `json:"parallelism"`
+	Parallelism int `json:"parallelism" yaml:"parallelism"`
 }
 
+// HelmConfig holds the chart to be used by helm.
 type HelmConfig struct {
-	Chart string `json:"chart"`
+	Chart string `json:"chart" yaml:"chart"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMerge(t *testing.T) {
+	one := &Config{Manifest: "foo.yaml"}
+	two := &Config{Manifest: "bar.yaml", Values: "baz.yaml"}
+
+	one.Merge(two)
+
+	assert.Equal(t, "foo.yaml", one.Manifest)
+	assert.Equal(t, "baz.yaml", one.Values)
+}
+
 func TestApplyDefaults(t *testing.T) {
 	c := &Config{WorkingDir: "/tmp"}
 	c.ApplyDefaults()
@@ -25,6 +35,7 @@ func TestUpdateClusterConfig(t *testing.T) {
 	values := map[string]interface{}{
 		"server":     "https://localhost:6443",
 		"kubeconfig": "/tmp/kubeconfig",
+		"context":    "minikube",
 	}
 
 	cfg.Update(values)
@@ -32,4 +43,5 @@ func TestUpdateClusterConfig(t *testing.T) {
 	assert.Equal(t, "https://localhost:6443", cfg.Server)
 	assert.Equal(t, "~/.kube/config", cfg.Kubeconfig)
 	assert.Equal(t, "supersecret", cfg.Token)
+	assert.Equal(t, "minikube", cfg.Context)
 }


### PR DESCRIPTION
This PR closes #1 and adds:

- `--config` flag for defining a custom yaml config file
- `dump-config` subcommand for debugging
- validation for `--output` flag (currently used by `version` and `dump-config` subcommands)