### PR TITLE
switch to using global logger

### DIFF
--- a/cmd/kcm/main.go
+++ b/cmd/kcm/main.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmd"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,19 +18,15 @@ var (
 )
 
 func init() {
-	logger := log.New()
-
 	cmdutil.AddGlobalFlags(rootCmd)
 
-	rootCmd.AddCommand(cmd.NewProvisionCommand(logger))
-	rootCmd.AddCommand(cmd.NewDestroyCommand(logger))
-	rootCmd.AddCommand(cmd.NewManifestsCommand(logger))
+	rootCmd.AddCommand(cmd.NewProvisionCommand())
+	rootCmd.AddCommand(cmd.NewDestroyCommand())
+	rootCmd.AddCommand(cmd.NewManifestsCommand())
 	rootCmd.AddCommand(cmd.NewDumpConfigCommand(os.Stdout))
 	rootCmd.AddCommand(cmd.NewVersionCommand(os.Stdout))
 
-	cobra.OnInitialize(func() {
-		cmdutil.ConfigureLogger(logger)
-	})
+	cobra.OnInitialize(cmdutil.ConfigureLogging)
 }
 
 func main() {

--- a/pkg/cluster/deletions.go
+++ b/pkg/cluster/deletions.go
@@ -15,13 +15,12 @@ type Deletions struct {
 
 func processResourceDeletions(
 	o *Options,
-	l *log.Logger,
 	kubectl *kubernetes.Kubectl,
 	resources []*kubernetes.ResourceSelector,
 ) ([]*kubernetes.ResourceSelector, error) {
 	if o.DryRun && len(resources) > 0 {
 		buf, _ := yaml.Marshal(resources)
-		l.Warnf("Would delete the following resources:\n%s", string(buf))
+		log.Warnf("Would delete the following resources:\n%s", string(buf))
 		return resources, nil
 	}
 

--- a/pkg/cluster/deletions_test.go
+++ b/pkg/cluster/deletions_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/martinohmann/kubernetes-cluster-manager/internal/commandtest"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/credentials"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/kubernetes"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +15,7 @@ func TestProcessResourceDeletions(t *testing.T) {
 
 		deletions := []*kubernetes.ResourceSelector{{Name: "foo", Kind: "pod"}}
 
-		remaining, err := processResourceDeletions(&Options{}, log.New(), kubectl, deletions)
+		remaining, err := processResourceDeletions(&Options{}, kubectl, deletions)
 
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 0)
@@ -29,7 +28,7 @@ func TestProcessResourceDeletionsDryRun(t *testing.T) {
 
 		deletions := []*kubernetes.ResourceSelector{{Name: "foo", Kind: "pod"}}
 
-		remaining, err := processResourceDeletions(&Options{DryRun: true}, log.New(), kubectl, deletions)
+		remaining, err := processResourceDeletions(&Options{DryRun: true}, kubectl, deletions)
 
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 1)

--- a/pkg/cluster/manager_test.go
+++ b/pkg/cluster/manager_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/file"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/provisioner"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/renderer"
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,7 +22,6 @@ func createManager() *Manager {
 		credentials.NewStaticSource(&credentials.Credentials{Context: "test"}),
 		provisioner.NewTerraform(&provisioner.Options{}),
 		renderer.NewHelm(&renderer.Options{TemplatesDir: "testdata/charts"}),
-		log.StandardLogger(),
 	)
 
 	return m
@@ -161,7 +159,6 @@ func TestReadCredentials(t *testing.T) {
 
 	m := &Manager{
 		credentialSource: credentials.NewStaticSource(expected),
-		logger:           log.StandardLogger(),
 	}
 
 	creds, err := m.readCredentials(&Options{})

--- a/pkg/cmd/destroy.go
+++ b/pkg/cmd/destroy.go
@@ -3,12 +3,11 @@ package cmd
 import (
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func NewDestroyCommand(l *log.Logger) *cobra.Command {
-	o := &Options{logger: l}
+func NewDestroyCommand() *cobra.Command {
+	o := &Options{}
 
 	cmd := &cobra.Command{
 		Use:   "destroy",

--- a/pkg/cmd/manifests.go
+++ b/pkg/cmd/manifests.go
@@ -3,25 +3,24 @@ package cmd
 import (
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func NewManifestsCommand(l *log.Logger) *cobra.Command {
+func NewManifestsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "manifests",
 		Aliases: []string{"manifest"},
 		Short:   "Perform manifest actions",
 	}
 
-	cmd.AddCommand(newApplyCommand(l))
-	cmd.AddCommand(newDeleteCommand(l))
+	cmd.AddCommand(newApplyCommand())
+	cmd.AddCommand(newDeleteCommand())
 
 	return cmd
 }
 
-func newApplyCommand(l *log.Logger) *cobra.Command {
-	o := &Options{logger: l}
+func newApplyCommand() *cobra.Command {
+	o := &Options{}
 
 	cmd := &cobra.Command{
 		Use:   "apply",
@@ -42,8 +41,8 @@ func newApplyCommand(l *log.Logger) *cobra.Command {
 	return cmd
 }
 
-func newDeleteCommand(l *log.Logger) *cobra.Command {
-	o := &Options{logger: l}
+func newDeleteCommand() *cobra.Command {
+	o := &Options{}
 
 	cmd := &cobra.Command{
 		Use:   "delete",

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -7,7 +7,6 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
-	"github.com/martinohmann/kubernetes-cluster-manager/pkg/command"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/credentials"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/file"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/provisioner"
@@ -27,8 +26,6 @@ type Options struct {
 	ManagerOptions     cluster.Options         `json:"managerOptions,omitempty" yaml:"managerOptions,omitempty"`
 	ProvisionerOptions provisioner.Options     `json:"provisionerOptions,omitempty" yaml:"provisionerOptions,omitempty"`
 	RendererOptions    renderer.Options        `json:"rendererOptions,omitempty" yaml:"rendererOptions,omitempty"`
-
-	logger *log.Logger
 }
 
 func (o *Options) AddFlags(cmd *cobra.Command) {
@@ -55,7 +52,7 @@ func (o *Options) Complete(cmd *cobra.Command) error {
 			return err
 		}
 
-		o.logger.Infof("Using config %s, config values take precedence over command line flags", color.YellowString(config))
+		log.Infof("Using config %s, config values take precedence over command line flags", color.YellowString(config))
 	}
 
 	o.WorkingDir, err = homedir.Expand(o.WorkingDir)
@@ -67,16 +64,12 @@ func (o *Options) Complete(cmd *cobra.Command) error {
 		o.Renderer = "null"
 	}
 
-	executor := command.NewExecutor(o.logger)
-
-	command.SetExecutor(executor)
-
 	return err
 }
 
 func (o *Options) Run(exec func(*cluster.Manager, *cluster.Options) error) error {
 	if o.WorkingDir != "" {
-		o.logger.Infof("Switching working dir to %s", o.WorkingDir)
+		log.Infof("Switching working dir to %s", o.WorkingDir)
 		if err := os.Chdir(o.WorkingDir); err != nil {
 			return err
 		}
@@ -120,10 +113,5 @@ func (o *Options) createManager() (*cluster.Manager, error) {
 		return nil, errors.New("please provide valid kubernetes credentials via the --cluster-* flags")
 	}
 
-	return cluster.NewManager(
-		credentialSource,
-		infraProvisioner,
-		manifestRenderer,
-		o.logger,
-	), nil
+	return cluster.NewManager(credentialSource, infraProvisioner, manifestRenderer), nil
 }

--- a/pkg/cmd/options_test.go
+++ b/pkg/cmd/options_test.go
@@ -7,13 +7,12 @@ import (
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/credentials"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/file"
 	homedir "github.com/mitchellh/go-homedir"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOptionsComplete(t *testing.T) {
-	o := &Options{logger: log.StandardLogger()}
+	o := &Options{}
 
 	config := `---
 workingDir: ~/foo

--- a/pkg/cmd/provision.go
+++ b/pkg/cmd/provision.go
@@ -3,12 +3,11 @@ package cmd
 import (
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func NewProvisionCommand(l *log.Logger) *cobra.Command {
-	o := &Options{logger: l}
+func NewProvisionCommand() *cobra.Command {
+	o := &Options{}
 
 	cmd := &cobra.Command{
 		Use:   "provision",

--- a/pkg/cmdutil/helpers.go
+++ b/pkg/cmdutil/helpers.go
@@ -25,9 +25,9 @@ func CheckErr(err error) {
 	}
 
 	if debug {
-		logger.Errorf("%+v", err)
+		log.Errorf("%+v", err)
 	} else {
-		logger.Error(err)
+		log.Error(err)
 	}
 
 	os.Exit(code)

--- a/pkg/cmdutil/logging.go
+++ b/pkg/cmdutil/logging.go
@@ -10,23 +10,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var logger = log.StandardLogger()
-
-// ConfigureLogger configures l based on the values of parsed cli flags.
-func ConfigureLogger(l *log.Logger) {
-	logger = l
-
+// ConfigureLogging configures the standard logger based on the values of parsed
+// cli flags.
+func ConfigureLogging() {
 	if quiet && !debug {
-		logger.Out = ioutil.Discard
+		log.SetOutput(ioutil.Discard)
 	}
 
 	if !debug {
 		return
 	}
 
-	logger.SetLevel(log.DebugLevel)
-	logger.SetReportCaller(true)
-	logger.SetFormatter(&log.TextFormatter{
+	log.SetLevel(log.DebugLevel)
+	log.SetReportCaller(true)
+	log.SetFormatter(&log.TextFormatter{
 		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
 			pkg := "github.com/martinohmann/kubernetes-cluster-manager/"
 			repopath := fmt.Sprintf("%s/src/%s", os.Getenv("GOPATH"), pkg)

--- a/pkg/command/executor.go
+++ b/pkg/command/executor.go
@@ -129,7 +129,7 @@ func SetExecutor(e Executor) {
 func SetExecutorWithRestore(e Executor) func() {
 	prevExecutor := DefaultExecutor
 
-	DefaultExecutor = e
+	SetExecutor(e)
 
 	return func() {
 		DefaultExecutor = prevExecutor


### PR DESCRIPTION
this will make it easier to make use of the logger in provisioners and renderers. also there is barely any case where we would want to use different loggers in different components.