### PR TITLE
pass down ctx across API boundaries

### DIFF
--- a/pkg/cluster/deletions.go
+++ b/pkg/cluster/deletions.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -22,6 +23,7 @@ type Deletions struct {
 }
 
 func processResourceDeletions(
+	ctx context.Context,
 	o *Options,
 	kubectl *kubernetes.Kubectl,
 	resources []ResourceSelector,
@@ -32,10 +34,10 @@ func processResourceDeletions(
 		return resources, nil
 	}
 
-	return kubectl.DeleteResources(resources)
+	return kubectl.DeleteResources(ctx, resources)
 }
 
-func deleteManifest(o *Options, kubectl *kubernetes.Kubectl, manifest *manifest.Manifest) error {
+func deleteManifest(ctx context.Context, o *Options, kubectl *kubernetes.Kubectl, manifest *manifest.Manifest) error {
 	filename := filepath.Join(o.ManifestsDir, manifest.Filename())
 
 	if o.DryRun {
@@ -43,7 +45,7 @@ func deleteManifest(o *Options, kubectl *kubernetes.Kubectl, manifest *manifest.
 		log.Debug(string(manifest.Content))
 	} else {
 		log.Infof("Deleting manifest %s", filename)
-		if err := kubectl.DeleteManifest(manifest.Content); err != nil {
+		if err := kubectl.DeleteManifest(ctx, manifest.Content); err != nil {
 			return err
 		}
 

--- a/pkg/cluster/deletions_test.go
+++ b/pkg/cluster/deletions_test.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"testing"
 
 	"github.com/martinohmann/kubernetes-cluster-manager/internal/commandtest"
@@ -15,7 +16,7 @@ func TestProcessResourceDeletions(t *testing.T) {
 
 		deletions := []ResourceSelector{{Name: "foo", Kind: "pod"}}
 
-		remaining, err := processResourceDeletions(&Options{}, kubectl, deletions)
+		remaining, err := processResourceDeletions(context.Background(), &Options{}, kubectl, deletions)
 
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 0)
@@ -28,7 +29,7 @@ func TestProcessResourceDeletionsDryRun(t *testing.T) {
 
 		deletions := []ResourceSelector{{Name: "foo", Kind: "pod"}}
 
-		remaining, err := processResourceDeletions(&Options{DryRun: true}, kubectl, deletions)
+		remaining, err := processResourceDeletions(context.Background(), &Options{DryRun: true}, kubectl, deletions)
 
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 1)

--- a/pkg/cluster/manager_test.go
+++ b/pkg/cluster/manager_test.go
@@ -3,6 +3,7 @@
 package cluster
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -82,7 +83,7 @@ preDestroy: []
 foo: output-from-terraform
 `
 
-		assert.NoError(t, p.Provision(o))
+		assert.NoError(t, p.Provision(context.Background(), o))
 
 		buf, _ := ioutil.ReadFile(filepath.Join(manifestsDir, "testchart.yaml"))
 
@@ -131,7 +132,7 @@ postApply: []
 preDestroy: []
 `
 
-		assert.NoError(t, p.Destroy(o))
+		assert.NoError(t, p.Destroy(context.Background(), o))
 
 		buf, _ := ioutil.ReadFile(deletions.Name())
 
@@ -144,7 +145,7 @@ func TestReadEmptyCredentials(t *testing.T) {
 		credentialSource: credentials.NewStaticSource(&credentials.Credentials{}),
 	}
 
-	_, err := m.readCredentials(&Options{})
+	_, err := m.readCredentials(context.Background(), &Options{})
 
 	assert.Error(t, err)
 }
@@ -159,7 +160,7 @@ func TestReadCredentials(t *testing.T) {
 		credentialSource: credentials.NewStaticSource(expected),
 	}
 
-	creds, err := m.readCredentials(&Options{})
+	creds, err := m.readCredentials(context.Background(), &Options{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, expected, creds)

--- a/pkg/cmd/destroy.go
+++ b/pkg/cmd/destroy.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -16,8 +18,8 @@ func NewDestroyCommand() *cobra.Command {
 			"in the manifest and afterwards deleting all infrastructure resources.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd))
-			cmdutil.CheckErr(o.Run(func(m *cluster.Manager, o *cluster.Options) error {
-				return m.Destroy(o)
+			cmdutil.CheckErr(o.Run(func(ctx context.Context, m *cluster.Manager, o *cluster.Options) error {
+				return m.Destroy(ctx, o)
 			}))
 		},
 	}

--- a/pkg/cmd/manifests.go
+++ b/pkg/cmd/manifests.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -28,8 +30,8 @@ func newApplyCommand() *cobra.Command {
 		Long:  "Renders manifests and applies them to a cluster.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd))
-			cmdutil.CheckErr(o.Run(func(m *cluster.Manager, o *cluster.Options) error {
-				return m.ApplyManifests(o)
+			cmdutil.CheckErr(o.Run(func(ctx context.Context, m *cluster.Manager, o *cluster.Options) error {
+				return m.ApplyManifests(ctx, o)
 			}))
 		},
 	}
@@ -50,8 +52,8 @@ func newDeleteCommand() *cobra.Command {
 		Long:  "Renders manifests and deletes them from a cluster.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd))
-			cmdutil.CheckErr(o.Run(func(m *cluster.Manager, o *cluster.Options) error {
-				return m.DeleteManifests(o)
+			cmdutil.CheckErr(o.Run(func(ctx context.Context, m *cluster.Manager, o *cluster.Options) error {
+				return m.DeleteManifests(ctx, o)
 			}))
 		},
 	}

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/fatih/color"
@@ -67,7 +68,7 @@ func (o *Options) Complete(cmd *cobra.Command) error {
 	return err
 }
 
-func (o *Options) Run(exec func(*cluster.Manager, *cluster.Options) error) error {
+func (o *Options) Run(exec func(context.Context, *cluster.Manager, *cluster.Options) error) error {
 	if o.WorkingDir != "" {
 		log.Infof("Switching working dir to %s", o.WorkingDir)
 		if err := os.Chdir(o.WorkingDir); err != nil {
@@ -80,7 +81,10 @@ func (o *Options) Run(exec func(*cluster.Manager, *cluster.Options) error) error
 		return err
 	}
 
-	return exec(m, &o.ManagerOptions)
+	// TODO(mohmann): this is the place where we should setup proper signal handling.
+	ctx := context.Background()
+
+	return exec(ctx, m, &o.ManagerOptions)
 }
 
 func (o *Options) MergeConfig(filename string) error {

--- a/pkg/cmd/provision.go
+++ b/pkg/cmd/provision.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cluster"
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/cmdutil"
 	"github.com/spf13/cobra"
@@ -16,8 +18,8 @@ func NewProvisionCommand() *cobra.Command {
 			"resources and afterwards applying Kubernetes manifests.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd))
-			cmdutil.CheckErr(o.Run(func(m *cluster.Manager, o *cluster.Options) error {
-				return m.Provision(o)
+			cmdutil.CheckErr(o.Run(func(ctx context.Context, m *cluster.Manager, o *cluster.Options) error {
+				return m.Provision(ctx, o)
 			}))
 		},
 	}

--- a/pkg/credentials/credentials.go
+++ b/pkg/credentials/credentials.go
@@ -1,5 +1,7 @@
 package credentials
 
+import "context"
+
 var (
 	// Empty are empty credentials.
 	Empty = Credentials{}
@@ -9,7 +11,7 @@ var (
 type Source interface {
 	// GetCredentials returns credentials for a Kubernetes cluster. Will return
 	// an error if retrieving credentials fails.
-	GetCredentials() (*Credentials, error)
+	GetCredentials(context.Context) (*Credentials, error)
 }
 
 // Credentials holds the credentials needed to communicate with a Kubernetes

--- a/pkg/credentials/output.go
+++ b/pkg/credentials/output.go
@@ -1,6 +1,8 @@
 package credentials
 
 import (
+	"context"
+
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/provisioner"
 )
 
@@ -16,8 +18,8 @@ func NewProvisionerOutputSource(o provisioner.Outputter) Source {
 }
 
 // GetCredentials implements Source.
-func (s *ProvisionerOutputSource) GetCredentials() (*Credentials, error) {
-	v, err := s.o.Output()
+func (s *ProvisionerOutputSource) GetCredentials(ctx context.Context) (*Credentials, error) {
+	v, err := s.o.Output(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/credentials/output_test.go
+++ b/pkg/credentials/output_test.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"context"
 	"testing"
 
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/kcm"
@@ -9,7 +10,7 @@ import (
 
 type testOutputter struct{}
 
-func (testOutputter) Output() (kcm.Values, error) {
+func (testOutputter) Output(ctx context.Context) (kcm.Values, error) {
 	return kcm.Values{
 		"kubeconfig": "/tmp/kubeconfig",
 	}, nil
@@ -18,7 +19,7 @@ func (testOutputter) Output() (kcm.Values, error) {
 func TestProvisionerOutputSource(t *testing.T) {
 	p := NewProvisionerOutputSource(testOutputter{})
 
-	credentials, err := p.GetCredentials()
+	credentials, err := p.GetCredentials(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, "/tmp/kubeconfig", credentials.Kubeconfig)

--- a/pkg/credentials/static.go
+++ b/pkg/credentials/static.go
@@ -1,5 +1,7 @@
 package credentials
 
+import "context"
+
 // StaticSource is a Source that holds static Kubernetes credentials.
 type StaticSource struct {
 	c *Credentials
@@ -11,6 +13,6 @@ func NewStaticSource(c *Credentials) Source {
 }
 
 // GetCredentials implements Source.
-func (p *StaticSource) GetCredentials() (*Credentials, error) {
+func (p *StaticSource) GetCredentials(ctx context.Context) (*Credentials, error) {
 	return p.c, nil
 }

--- a/pkg/credentials/static_test.go
+++ b/pkg/credentials/static_test.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ func TestStaticSource(t *testing.T) {
 
 	p := NewStaticSource(c)
 
-	credentials, err := p.GetCredentials()
+	credentials, err := p.GetCredentials(context.Background())
 
 	assert.NoError(t, err)
 	assert.Exactly(t, c, credentials)

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -22,10 +23,10 @@ var (
 // WaitForCluster waits until the api-server is reachable. Will retry every 2
 // seconds in case of error. After 30 failed attempts it will give up and
 // return the last error.
-func (k *Kubectl) WaitForCluster() error {
+func (k *Kubectl) WaitForCluster(ctx context.Context) error {
 	err := backoff.Retry(
 		func() error {
-			out, err := k.ClusterInfo()
+			out, err := k.ClusterInfo(ctx)
 			return errors.Wrapf(err, "failed to connect to cluster due to:\n%s", out)
 		},
 		pollingStrategy,

--- a/pkg/kubernetes/kubectl.go
+++ b/pkg/kubernetes/kubectl.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -40,7 +41,7 @@ func NewKubectl(c *credentials.Credentials) *Kubectl {
 }
 
 // ApplyManifest applies the manifest via kubectl.
-func (k *Kubectl) ApplyManifest(manifest []byte) error {
+func (k *Kubectl) ApplyManifest(ctx context.Context, manifest []byte) error {
 	args := []string{
 		"kubectl",
 		"apply",
@@ -64,7 +65,7 @@ func (k *Kubectl) ApplyManifest(manifest []byte) error {
 }
 
 // DeleteManifest deletes the manifest via kubectl.
-func (k *Kubectl) DeleteManifest(manifest []byte) error {
+func (k *Kubectl) DeleteManifest(ctx context.Context, manifest []byte) error {
 	args := []string{
 		"kubectl",
 		"delete",
@@ -89,7 +90,7 @@ func (k *Kubectl) DeleteManifest(manifest []byte) error {
 }
 
 // DeleteResource deletes a resource via kubectl.
-func (k *Kubectl) DeleteResource(selector ResourceSelector) error {
+func (k *Kubectl) DeleteResource(ctx context.Context, selector ResourceSelector) error {
 	namespace := selector.Namespace
 	if namespace == "" {
 		namespace = DefaultNamespace
@@ -139,9 +140,9 @@ func (k *Kubectl) DeleteResource(selector ResourceSelector) error {
 
 // DeleteResources deletes resources via kubectl. Returns a slice containing
 // the resources that were not deleted to to an error.
-func (k *Kubectl) DeleteResources(resources []ResourceSelector) ([]ResourceSelector, error) {
+func (k *Kubectl) DeleteResources(ctx context.Context, resources []ResourceSelector) ([]ResourceSelector, error) {
 	for i, selector := range resources {
-		if err := k.DeleteResource(selector); err != nil {
+		if err := k.DeleteResource(ctx, selector); err != nil {
 			return resources[i:], err
 		}
 	}
@@ -150,7 +151,7 @@ func (k *Kubectl) DeleteResources(resources []ResourceSelector) ([]ResourceSelec
 }
 
 // ClusterInfo fetches the kubernetes cluster info.
-func (k *Kubectl) ClusterInfo() (string, error) {
+func (k *Kubectl) ClusterInfo(ctx context.Context) (string, error) {
 	args := []string{
 		"kubectl",
 		"cluster-info",

--- a/pkg/kubernetes/kubectl_test.go
+++ b/pkg/kubernetes/kubectl_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/martinohmann/kubernetes-cluster-manager/internal/commandtest"
@@ -17,7 +18,7 @@ func TestApplyManifest(t *testing.T) {
 
 		kubectl := NewKubectl(creds)
 
-		err := kubectl.ApplyManifest([]byte{})
+		err := kubectl.ApplyManifest(context.Background(), []byte{})
 
 		assert.NoError(t, err)
 		if assert.Len(t, executor.ExecutedCommands, 1) {
@@ -39,7 +40,7 @@ func TestDeleteManifest(t *testing.T) {
 
 		kubectl := NewKubectl(creds)
 
-		err := kubectl.DeleteManifest([]byte{})
+		err := kubectl.DeleteManifest(context.Background(), []byte{})
 
 		assert.NoError(t, err)
 		if assert.Len(t, executor.ExecutedCommands, 1) {
@@ -65,7 +66,7 @@ func TestDeleteResource(t *testing.T) {
 
 		kubectl := NewKubectl(creds)
 
-		err := kubectl.DeleteResource(selector)
+		err := kubectl.DeleteResource(context.Background(), selector)
 
 		assert.NoError(t, err)
 		if assert.Len(t, executor.ExecutedCommands, 1) {
@@ -97,7 +98,7 @@ func TestDeleteResources(t *testing.T) {
 
 		executor.NextCommand().WillSucceed()
 
-		remaining, err := kubectl.DeleteResources(resources)
+		remaining, err := kubectl.DeleteResources(context.Background(), resources)
 
 		assert.NoError(t, err)
 		assert.Len(t, remaining, 0)
@@ -130,7 +131,7 @@ func TestDeleteResourcesError(t *testing.T) {
 		executor.NextCommand().WillSucceed()
 		executor.NextCommand().WillError()
 
-		remaining, err := kubectl.DeleteResources(resources)
+		remaining, err := kubectl.DeleteResources(context.Background(), resources)
 
 		assert.Error(t, err)
 		assert.Len(t, remaining, 1)
@@ -153,7 +154,7 @@ func TestDeleteResourceLabels(t *testing.T) {
 
 		kubectl := NewKubectl(creds)
 
-		err := kubectl.DeleteResource(selector)
+		err := kubectl.DeleteResource(context.Background(), selector)
 
 		assert.NoError(t, err)
 		if assert.Len(t, executor.ExecutedCommands, 1) {
@@ -178,7 +179,7 @@ func TestDeleteResourceMissingSelector(t *testing.T) {
 
 		kubectl := NewKubectl(creds)
 
-		err := kubectl.DeleteResource(selector)
+		err := kubectl.DeleteResource(context.Background(), selector)
 
 		assert.Error(t, err)
 		assert.EqualError(t, err, "either a name or labels must be specified in the resource selector (kind=pod,namespace=default)")

--- a/pkg/provisioner/minikube.go
+++ b/pkg/provisioner/minikube.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
@@ -15,7 +16,7 @@ import (
 type Minikube struct{}
 
 // NewMinikube creates a new Minikube provisioner.
-func NewMinikube(_ *Options) Provisioner {
+func NewMinikube(o *Options) Provisioner {
 	return &Minikube{}
 }
 
@@ -31,7 +32,7 @@ func (m *Minikube) status() error {
 }
 
 // Provision implements Provision from the Provisioner interface.
-func (m *Minikube) Provision() error {
+func (m *Minikube) Provision(ctx context.Context) error {
 	if err := m.status(); err == nil {
 		return nil
 	}
@@ -44,7 +45,7 @@ func (m *Minikube) Provision() error {
 }
 
 // Output implements Outputter.
-func (m *Minikube) Output() (kcm.Values, error) {
+func (m *Minikube) Output(ctx context.Context) (kcm.Values, error) {
 	home, _ := homedir.Dir()
 
 	v := kcm.Values{
@@ -56,7 +57,7 @@ func (m *Minikube) Output() (kcm.Values, error) {
 }
 
 // Destroy implements Destroy from the Provisioner interface.
-func (m *Minikube) Destroy() error {
+func (m *Minikube) Destroy(ctx context.Context) error {
 	if err := m.status(); err != nil {
 		return err
 	}

--- a/pkg/provisioner/minikube_test.go
+++ b/pkg/provisioner/minikube_test.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"testing"
 
 	"github.com/martinohmann/kubernetes-cluster-manager/internal/commandtest"
@@ -16,7 +17,7 @@ func TestMinikubeProvision(t *testing.T) {
 		executor.Command("minikube status").WillError()
 		executor.Command("minikube start").WillSucceed()
 
-		err := m.Provision()
+		err := m.Provision(context.Background())
 
 		assert.NoError(t, err)
 	})
@@ -32,7 +33,7 @@ func TestMinikubeOutput(t *testing.T) {
 		"kubeconfig": home + "/.kube/config",
 	}
 
-	values, err := m.Output()
+	values, err := m.Output(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedValues, values)
@@ -45,7 +46,7 @@ func TestMinikubeDestroy(t *testing.T) {
 		executor.Command("minikube status").WillSucceed()
 		executor.Command("minikube delete").WillSucceed()
 
-		err := m.Destroy()
+		err := m.Destroy(context.Background())
 
 		assert.NoError(t, err)
 	})

--- a/pkg/provisioner/null.go
+++ b/pkg/provisioner/null.go
@@ -1,5 +1,7 @@
 package provisioner
 
+import "context"
+
 // Null does not provision any infrastructure. All interface funcs
 // will return successfully. Null can be used if you want to manage
 // your cluster infrastructure by other means and just want to make use of the
@@ -7,16 +9,16 @@ package provisioner
 type Null struct{}
 
 // NewNull creates a new Null provisioner.
-func NewNull(_ *Options) Provisioner {
+func NewNull(o *Options) Provisioner {
 	return &Null{}
 }
 
 // Provision implements Provision from the Provisioner interface.
-func (*Null) Provision() error {
+func (*Null) Provision(ctx context.Context) error {
 	return nil
 }
 
 // Destroy implements Destroy from the Provisioner interface.
-func (*Null) Destroy() error {
+func (*Null) Destroy(ctx context.Context) error {
 	return nil
 }

--- a/pkg/provisioner/null_test.go
+++ b/pkg/provisioner/null_test.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,6 @@ import (
 func TestNull(t *testing.T) {
 	p := NewNull(&Options{})
 
-	require.NoError(t, p.Provision())
-	require.NoError(t, p.Destroy())
+	require.NoError(t, p.Provision(context.Background()))
+	require.NoError(t, p.Destroy(context.Background()))
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1,6 +1,8 @@
 package provisioner
 
 import (
+	"context"
+
 	"github.com/martinohmann/kubernetes-cluster-manager/pkg/kcm"
 )
 
@@ -8,25 +10,25 @@ import (
 type Provisioner interface {
 	// Provision applies changes to the infrastructure. It should
 	// automatically create or update a kubernetes cluster.
-	Provision() error
+	Provision(context.Context) error
 
 	// Destroy performs all actions needed to destroy the underlying
 	// cluster infrastructure.
-	Destroy() error
+	Destroy(context.Context) error
 }
 
 // Reconciler can reconcile infrastucture status.
 type Reconciler interface {
 	// Reconcile retrieves the current state of the infrastructure and
 	// should log potential changes without actually applying them.
-	Reconcile() error
+	Reconcile(context.Context) error
 }
 
 // Outputter can output kcm.Values.
 type Outputter interface {
 	// Output obtains output values from the infrastructure provisioner. These
 	// values are made available during kubernetes manifest renderering.
-	Output() (kcm.Values, error)
+	Output(context.Context) (kcm.Values, error)
 }
 
 // Options are made available to infrastructure provisioners.

--- a/pkg/provisioner/terraform.go
+++ b/pkg/provisioner/terraform.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -37,7 +38,7 @@ func NewTerraform(o *Options) Provisioner {
 }
 
 // Provision implements Provision from the Provisioner interface.
-func (m *Terraform) Provision() error {
+func (m *Terraform) Provision(ctx context.Context) error {
 	args := []string{
 		"terraform",
 		"apply",
@@ -56,7 +57,7 @@ func (m *Terraform) Provision() error {
 }
 
 // Reconcile implements Reconciler.
-func (m *Terraform) Reconcile() (err error) {
+func (m *Terraform) Reconcile(ctx context.Context) (err error) {
 	args := []string{
 		"terraform",
 		"plan",
@@ -80,7 +81,7 @@ func (m *Terraform) Reconcile() (err error) {
 }
 
 // Output implements Outputter.
-func (m *Terraform) Output() (kcm.Values, error) {
+func (m *Terraform) Output(ctx context.Context) (kcm.Values, error) {
 	args := []string{
 		"terraform",
 		"output",
@@ -116,7 +117,7 @@ func (m *Terraform) Output() (kcm.Values, error) {
 }
 
 // Destroy implements Destroy from the Provisioner interface.
-func (m *Terraform) Destroy() error {
+func (m *Terraform) Destroy(ctx context.Context) error {
 	args := []string{
 		"terraform",
 		"destroy",

--- a/pkg/provisioner/terraform_test.go
+++ b/pkg/provisioner/terraform_test.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestTerraformProvision(t *testing.T) {
 
 		m := NewTerraform(options)
 
-		err := m.Provision()
+		err := m.Provision(context.Background())
 
 		if !assert.NoError(t, err) {
 			return
@@ -36,7 +37,7 @@ func TestTerraformReconcile(t *testing.T) {
 	commandtest.WithMockExecutor(func(executor *commandtest.MockExecutor) {
 		m := &Terraform{}
 
-		err := m.Reconcile()
+		err := m.Reconcile(context.Background())
 
 		if !assert.NoError(t, err) {
 			return
@@ -73,7 +74,7 @@ func TestTerraformOutput(t *testing.T) {
 			"bar": []interface{}{"baz"},
 		}
 
-		values, err := m.Output()
+		values, err := m.Output(context.Background())
 
 		if !assert.NoError(t, err) {
 			return
@@ -100,7 +101,7 @@ func TestTerraformOutputIssue21(t *testing.T) {
 			errors.New(color.RedString("The module root could not be found. There is nothing to output.")),
 		)
 
-		values, err := m.Output()
+		values, err := m.Output(context.Background())
 
 		assert.NoError(t, err)
 		assert.Equal(t, kcm.Values{}, values)
@@ -113,7 +114,7 @@ func TestTerraformDestroy(t *testing.T) {
 
 		m := NewTerraform(options)
 
-		err := m.Destroy()
+		err := m.Destroy(context.Background())
 
 		if !assert.NoError(t, err) {
 			return


### PR DESCRIPTION
This addresses issue #34. It only adds the context to function signatures where needed but does not make use of it yet.

Signal handling (#38) via context will be implemented in a separate PR.