### PR TITLE
make retry logic aware of context cancellations

### DIFF
--- a/pkg/kubernetes/kubectl.go
+++ b/pkg/kubernetes/kubectl.go
@@ -56,7 +56,7 @@ func (k *Kubectl) ApplyManifest(ctx context.Context, manifest []byte) error {
 			_, err := command.RunWithContext(ctx, cmd)
 			return err
 		},
-		backoffStrategy,
+		backoff.WithContext(backoffStrategy, ctx),
 	)
 
 	return err
@@ -81,7 +81,7 @@ func (k *Kubectl) DeleteManifest(ctx context.Context, manifest []byte) error {
 			_, err := command.RunWithContext(ctx, cmd)
 			return err
 		},
-		backoffStrategy,
+		backoff.WithContext(backoffStrategy, ctx),
 	)
 
 	return err
@@ -112,7 +112,7 @@ func (k *Kubectl) DeleteResource(ctx context.Context, selector resource.Head) er
 			_, err := command.RunWithContext(ctx, cmd)
 			return err
 		},
-		backoffStrategy,
+		backoff.WithContext(backoffStrategy, ctx),
 	)
 
 	return err

--- a/pkg/kubernetes/wait.go
+++ b/pkg/kubernetes/wait.go
@@ -72,7 +72,7 @@ func (k *Kubectl) WaitForCluster(ctx context.Context) error {
 			out, err := k.ClusterInfo(ctx)
 			return errors.Wrapf(err, "failed to connect to cluster due to:\n%s", out)
 		},
-		pollingStrategy,
+		backoff.WithContext(pollingStrategy, ctx),
 	)
 
 	return err


### PR DESCRIPTION
This fixes a bug where sending ctrl+c would not terminate the retry logic, causing it to retry until it's max number is reached.